### PR TITLE
Hack solution for #172 three char abbrs. at Pole Sud,

### DIFF
--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -386,6 +386,7 @@ func getDate(f *Field, s *goquery.Selection) (time.Time, error) {
 		dateTimeString += dp.stringPart + " "
 	}
 	dateTimeString = strings.Replace(dateTimeString, "Mrz", "Mär", 1) // hack for issue #47
+	dateTimeString = strings.Replace(dateTimeString, "Fév", "févr", 1) // hack for issue #172
 	for _, dateTimeLayout := range dateTimeLayouts {
 		t, err = monday.ParseInLocation(dateTimeLayout, dateTimeString, loc, monday.Locale(mLocale))
 		if err == nil {


### PR DESCRIPTION
It appears that golang fr_FR uses four character abbreviations for French, but Pôle Sud in Lausanne use three character abbreviations.

This will probably need a systemic solution at some point, but I don't know if that should be in the config.yml or somewhere else.