### PR TITLE
Feature/date filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ scrapers:
         date_location: "Europe/Berlin"
     filters:
       - field: "title"
-        regex: "Verschoben.*"
+        exp: "Verschoben.*"
         match: false
       - field: "title"
-        regex: "Abgesagt.*"
+        exp: "Abgesagt.*"
         match: false
 ```
 
@@ -424,19 +424,24 @@ Since version 0.3.0 js rendering is supported. For this to work the `google-chro
 
 ### Filters
 
-Filters can be used to define what items should make it into the resulting list of items. A filter configuration looks as follows:
+Filters can be used to define what items should make it into the resulting list of items. A filter configuration can look as follows:
 
 ```yml
 filters:
   - field: "status"
-    regex: "cancelled"
+    exp: "cancelled"
     match: false
   - field: "status"
-    regex: "delayed"
+    exp: ".*(?i)(delayed).*"
     match: false
+  - field: "date"
+    exp: "> now" # format: <|> now|YYYY-MM-ddTHH:mm
+    match: true
 ```
 
-The `field` key determines to which field the regular expression will be applied. `regex` defines the regular expression and `match` determines whether the item should be included or excluded on match. Note, that as soon as there is one match for a regular expression that has `match` set to **false** the respective item will be exlcuded from the results without looking at the other filters.
+The `field` key determines to which field the expression will be applied. `exp` defines the expression and `match` determines whether the item should be included or excluded on match. Note, that as soon as there is one match for an expression that has `match` set to **false** the respective item will be excluded from the results without looking at the other filters.
+
+The expression `exp` can be either a regular expression or a date comparison. Depending on the type of the respective `field` in the `fields` section of the configuration it has to be either one or the other. If the corresponding field is of type `date` the expression has to be a date comparison. For every other field type it has to be a regular expression.
 
 ### Interaction
 

--- a/concerts-config.yml
+++ b/concerts-config.yml
@@ -91,13 +91,13 @@ scrapers:
         date_language: "it_IT"
     filters:
       - field: "title"
-        regex: ".*CANCELED.*"
+        exp: ".*CANCELED.*"
         match: false
       - field: "title"
-        regex: "ANNULLATO!.*"
+        exp: "ANNULLATO!.*"
         match: false
       - field: "title"
-        regex: ".*Postponed.*"
+        exp: ".*Postponed.*"
         match: false
     paginator:
       location:
@@ -164,10 +164,10 @@ scrapers:
         selector: ".pager__item a"
     filters:
       - field: "title"
-        regex: ".*POSTPONED.*"
+        exp: ".*POSTPONED.*"
         match: false
       - field: "title"
-        regex: ".*CANCELLED.*"
+        exp: ".*CANCELLED.*"
         match: false
 
   ##########
@@ -321,16 +321,16 @@ scrapers:
         date_location: "Europe/Berlin"
     filters:
       - field: "location"
-        regex: "Zenith" # duplicate (also present on Motorworld website)
+        exp: "Zenith" # duplicate (also present on Motorworld website)
         match: false
       - field: "location"
-        regex: "Strom" # duplicate
+        exp: "Strom" # duplicate
         match: false
       - field: "location"
-        regex: "Tonhalle" # duplicate
+        exp: "Tonhalle" # duplicate
         match: false
       - field: "location"
-        regex: "TonHalle" # duplicate
+        exp: "TonHalle" # duplicate
         match: false
 
   #########

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -82,6 +82,11 @@ const (
 func TestFilterItemMatchTrue(t *testing.T) {
 	item := map[string]interface{}{"title": "Jacob Collier - Concert"}
 	s := &Scraper{
+		Fields: []Field{
+			{
+				Name: "title",
+			},
+		},
 		Filters: []*Filter{
 			{
 				Field:      "title",
@@ -90,10 +95,11 @@ func TestFilterItemMatchTrue(t *testing.T) {
 			},
 		},
 	}
-	f, err := s.filterItem(item)
+	err := s.initializeFilters()
 	if err != nil {
 		t.Fatalf("got unexpected error: %v", err)
 	}
+	f := s.filterItem(item)
 	if !f {
 		t.Fatalf("expected 'true' but got 'false'")
 	}
@@ -102,6 +108,11 @@ func TestFilterItemMatchTrue(t *testing.T) {
 func TestFilterItemMatchFalse(t *testing.T) {
 	item := map[string]interface{}{"title": "Jacob Collier - Cancelled"}
 	s := &Scraper{
+		Fields: []Field{
+			{
+				Name: "title",
+			},
+		},
 		Filters: []*Filter{
 			{
 				Field:      "title",
@@ -110,10 +121,95 @@ func TestFilterItemMatchFalse(t *testing.T) {
 			},
 		},
 	}
-	f, err := s.filterItem(item)
+	err := s.initializeFilters()
 	if err != nil {
 		t.Fatalf("got unexpected error: %v", err)
 	}
+	f := s.filterItem(item)
+	if f {
+		t.Fatalf("expected 'false' but got 'true'")
+	}
+}
+
+func TestFilterItemByDateMatchTrue(t *testing.T) {
+	loc, _ := time.LoadLocation("UTC")
+	item := map[string]interface{}{"date": time.Date(2023, 10, 20, 19, 1, 0, 0, loc)}
+	s := &Scraper{
+		Fields: []Field{
+			{
+				Name: "date",
+				Type: "date",
+			},
+		},
+		Filters: []*Filter{
+			{
+				Field:      "date",
+				Expression: "> 2023-10-20T19:00",
+				Match:      true,
+			},
+		},
+	}
+	err := s.initializeFilters()
+	if err != nil {
+		t.Fatalf("got unexpected error: %v", err)
+	}
+	f := s.filterItem(item)
+	if !f {
+		t.Fatalf("expected 'true' but got 'false'")
+	}
+}
+
+func TestFilterItemByDateMatchTrue2(t *testing.T) {
+	loc, _ := time.LoadLocation("UTC")
+	item := map[string]interface{}{"date": time.Date(2023, 10, 20, 19, 0, 0, 0, loc)}
+	s := &Scraper{
+		Fields: []Field{
+			{
+				Name: "date",
+				Type: "date",
+			},
+		},
+		Filters: []*Filter{
+			{
+				Field:      "date",
+				Expression: "> 2023-10-20T19:00",
+				Match:      true,
+			},
+		},
+	}
+	err := s.initializeFilters()
+	if err != nil {
+		t.Fatalf("got unexpected error: %v", err)
+	}
+	f := s.filterItem(item)
+	if f {
+		t.Fatalf("expected 'false' but got 'true'")
+	}
+}
+
+func TestFilterItemByDateMatchFalse(t *testing.T) {
+	loc, _ := time.LoadLocation("UTC")
+	item := map[string]interface{}{"date": time.Date(2023, 10, 20, 19, 1, 0, 0, loc)}
+	s := &Scraper{
+		Fields: []Field{
+			{
+				Name: "date",
+				Type: "date",
+			},
+		},
+		Filters: []*Filter{
+			{
+				Field:      "date",
+				Expression: "> 2023-10-20T19:00",
+				Match:      false,
+			},
+		},
+	}
+	err := s.initializeFilters()
+	if err != nil {
+		t.Fatalf("got unexpected error: %v", err)
+	}
+	f := s.filterItem(item)
 	if f {
 		t.Fatalf("expected 'false' but got 'true'")
 	}

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -82,11 +82,11 @@ const (
 func TestFilterItemMatchTrue(t *testing.T) {
 	item := map[string]interface{}{"title": "Jacob Collier - Concert"}
 	s := &Scraper{
-		Filters: []Filter{
+		Filters: []*Filter{
 			{
-				Field: "title",
-				Regex: ".*Concert",
-				Match: true,
+				Field:      "title",
+				Expression: ".*Concert",
+				Match:      true,
 			},
 		},
 	}
@@ -102,11 +102,11 @@ func TestFilterItemMatchTrue(t *testing.T) {
 func TestFilterItemMatchFalse(t *testing.T) {
 	item := map[string]interface{}{"title": "Jacob Collier - Cancelled"}
 	s := &Scraper{
-		Filters: []Filter{
+		Filters: []*Filter{
 			{
-				Field: "title",
-				Regex: ".*Cancelled",
-				Match: false,
+				Field:      "title",
+				Expression: ".*Cancelled",
+				Match:      false,
 			},
 		},
 	}


### PR DESCRIPTION
This PR solves issue #240

Note that there is a breaking change for the `filters` section in the configuration. Instead of `regex` the name of the field is now `exp` to accommodate for the more general nature of this field. It can now also be a date comparison instead of a regular expression, depending on the type of the respective field in the `fields` section of the configuration.