### PR TITLE
Fix url extraction for data: protocol

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -877,7 +877,13 @@ func getURLString(e *ElementLocation, s *goquery.Selection, baseURL string) (str
 	urlVal = strings.TrimSpace(urlVal)
 	if urlVal == "" {
 		return "", nil
-	} else if strings.HasPrefix(urlVal, "http") {
+	}
+
+	parsedURL, err := url.Parse(urlVal)
+	if err != nil {
+		return "", err
+	}
+	if parsedURL.Scheme != "" {
 		urlRes = urlVal
 	} else if strings.HasPrefix(urlVal, "?") || strings.HasPrefix(urlVal, ".?") {
 		urlVal = strings.TrimLeft(urlVal, ".")

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -656,6 +656,20 @@ func TestExtractFieldUrlOrText(t *testing.T) {
 			baseUrl:  "https://www.roxy.ulm.de/programm/programm.php",
 			expected: "https://www.roxy.ulm.de/programm/programm.php?m=4&j=2023&vid=4378",
 		},
+		"url data protocol": {
+			htmlString: `<html><body><a href="data:text/plain;base64,SGVsbG8=">Link</a></body></html>`,
+			field: &Field{
+				Name: "url",
+				Type: "url",
+				ElementLocations: []ElementLocation{
+					{
+						Selector: "a",
+					},
+				},
+			},
+			baseUrl:  "https://example.com/page",
+			expected: "data:text/plain;base64,SGVsbG8=",
+		},
 		"url parent dir": {
 			htmlString: htmlString6,
 			field: &Field{


### PR DESCRIPTION
## Summary
- preserve explicitly-schemed URL values such as data: during URL field extraction
- add a regression test covering data: protocol handling for url-type fields

## Testing
- go test ./internal/scraper
- go test ./...