### PR TITLE
small improvements

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -489,14 +489,17 @@ func (c *Scraper) guessYear(items []map[string]any, ref time.Time) {
 						// of 'now'.
 						// Obviously, this is still far from perfect and it only works in a certain
 						// number of cases.
+						referenceDate := ref
 						if i > 0 {
-							ref, _ = items[i-1][name].(time.Time)
+							if previousDate, ok := items[i-1][name].(time.Time); ok {
+								referenceDate = previousDate
+							}
 						}
 						diff := time.Since(time.Unix(0, 0))
 						newDate := t
-						for y := ref.Year() - 1; y <= ref.Year()+1; y++ {
+						for y := referenceDate.Year() - 1; y <= referenceDate.Year()+1; y++ {
 							tmpT := time.Date(y, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
-							if newDiff := tmpT.Sub(ref).Abs(); newDiff < diff {
+							if newDiff := tmpT.Sub(referenceDate).Abs(); newDiff < diff {
 								diff = newDiff
 								newDate = time.Date(y, t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 							}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -862,6 +862,34 @@ func TestGuessYear(t *testing.T) {
 			},
 			referenceDate: time.Date(2023, 11, 30, 20, 30, 0, 0, loc),
 		},
+		"guess year uses provided reference when prior item has no date": {
+			scraper: &Scraper{
+				Fields: []Field{
+					{
+						Type:      "date",
+						GuessYear: true,
+						Name:      "date",
+					},
+				},
+			},
+			items: []map[string]any{
+				{
+					"title": "Event without a date",
+				},
+				{
+					"date": time.Date(2023, 1, 2, 20, 0, 0, 0, loc),
+				},
+			},
+			expected: []map[string]any{
+				{
+					"title": "Event without a date",
+				},
+				{
+					"date": time.Date(2024, 1, 2, 20, 0, 0, 0, loc),
+				},
+			},
+			referenceDate: time.Date(2023, 12, 30, 20, 30, 0, 0, loc),
+		},
 		"guess year unordered": {
 			scraper: &Scraper{
 				Fields: []Field{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -61,17 +61,15 @@ func HSVToRGB(h, s, v float64) (int32, int32, int32) {
 	return int32(r), int32(g), int32(b)
 }
 
-// MostOcc returns the most occurring element in a slice of comparable elements.
+// MostOcc returns the most occurring element, preferring the first occurrence on ties.
 func MostOcc[T comparable](items []T) T {
-	count := map[T]int{}
-	for _, item := range items {
-		count[item]++
-	}
+	counts := map[T]int{}
 	var mostOcc T
 	maxOcc := 0
-	for item, c := range count {
-		if c > maxOcc {
-			maxOcc = c
+	for _, item := range items {
+		counts[item]++
+		if counts[item] > maxOcc {
+			maxOcc = counts[item]
 			mostOcc = item
 		}
 	}
@@ -100,6 +98,8 @@ func OnlyContainsDigits(s string) bool {
 
 // IntersectionSlices returns the intersection of two slices.
 func IntersectionSlices[T cmp.Ordered](a, b []T) []T {
+	a = slices.Clone(a)
+	b = slices.Clone(b)
 	slices.Sort(a)
 	slices.Sort(b)
 	result := []T{}
@@ -122,6 +122,8 @@ func SliceEquals[T cmp.Ordered](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	a = slices.Clone(a)
+	b = slices.Clone(b)
 	slices.Sort(a)
 	slices.Sort(b)
 	for i := range a {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestMostOcc_Int(t *testing.T) {
 	}{
 		{[]int{1, 2, 2, 3, 2, 4}, 2},
 		{[]int{5, 5, 5, 5}, 5},
-		// {[]int{1, 2, 3, 4}, 1}, // all unique, returns first seen; INCORRECT, returns random int
+		{[]int{1, 2, 3, 4}, 1},
 		{[]int{}, 0}, // zero value for int
 	}
 
@@ -51,7 +52,7 @@ func TestMostOcc_String(t *testing.T) {
 		expected string
 	}{
 		{[]string{"a", "b", "a", "c", "a"}, "a"},
-		// {[]string{"x", "y", "z"}, "x"}, // all unique, returns first seen; INCORRECT, returns random string
+		{[]string{"x", "y", "z"}, "x"},
 		{[]string{"foo", "foo", "bar"}, "foo"},
 		{[]string{}, ""}, // zero value for string
 	}
@@ -200,6 +201,25 @@ func TestSliceEquals_String(t *testing.T) {
 		if result != tt.expected {
 			t.Errorf("SliceEquals(%v, %v) = %v; want %v", tt.a, tt.b, result, tt.expected)
 		}
+	}
+}
+
+func TestSliceOperationsDoNotModifyInputs(t *testing.T) {
+	a := []int{3, 1, 2}
+	b := []int{2, 3, 1}
+
+	if !SliceEquals(a, b) {
+		t.Fatal("SliceEquals returned false for equal slices")
+	}
+	if !slices.Equal(a, []int{3, 1, 2}) || !slices.Equal(b, []int{2, 3, 1}) {
+		t.Fatalf("SliceEquals modified inputs: a=%v, b=%v", a, b)
+	}
+
+	if got := IntersectionSlices(a, b); !slices.Equal(got, []int{1, 2, 3}) {
+		t.Fatalf("IntersectionSlices() = %v, want [1 2 3]", got)
+	}
+	if !slices.Equal(a, []int{3, 1, 2}) || !slices.Equal(b, []int{2, 3, 1}) {
+		t.Fatalf("IntersectionSlices modified inputs: a=%v, b=%v", a, b)
 	}
 }
 


### PR DESCRIPTION
- utils.go: MostOcc is now deterministic on ties, returning the first occurring value. This affects date-format inference and ML prediction voting.
- utils.go: IntersectionSlices and SliceEquals no longer sort and mutate caller-owned slices.
- scraper.go: year guessing now retains the supplied reference date when the preceding event has no date, avoiding invalid years near Go’s zero time.